### PR TITLE
Add FastAPI backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Python
+venv/
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -71,3 +71,10 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Backend setup
+
+```sh
+poetry install
+uvicorn backend.main:app --reload
+```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+python-multipart
+pillow
+piexif
+openai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "geo-snap-mapper"
+version = "0.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "*"
+uvicorn = {version = "*", extras = ["standard"]}
+python-multipart = "*"
+pillow = "*"
+piexif = "*"
+openai = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` configured for FastAPI
- create `backend` directory with empty `main.py` and `requirements.txt`
- update `.gitignore` for Python artifacts
- document how to start the backend in `README.md`

## Testing
- `python3 --version`

------
https://chatgpt.com/codex/tasks/task_e_6884cb45d7ec832380b96090789593a3